### PR TITLE
update to Rust master

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -294,8 +294,8 @@ mod tests {
             *self as u32
         }
 
-        fn from_u32(v: u32) -> Foo {
-            unsafe { mem::transmute(v) }
+        unsafe fn from_u32(v: u32) -> Foo {
+            mem::transmute(v)
         }
     }
 


### PR DESCRIPTION
Traits' unsafe methods can no longer be implemented with safe ones.
