### PR TITLE
Semi-hacky fix to get compiling on the beta channel

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,17 +13,11 @@
 //! This module defines a container which uses an efficient bit mask
 //! representation to hold C-like enum variants.
 
-#![feature(core)]
-#![cfg_attr(test, feature(test))]
-
 #![allow(raw_pointer_derive)]
-
-#[cfg(test)] extern crate test;
 
 use std::fmt;
 use std::hash;
 use std::marker::PhantomData;
-use std::u32;
 use std::iter::{self, IntoIterator};
 use std::ops;
 
@@ -91,8 +85,7 @@ pub trait CLike {
 
 fn bit<E:CLike>(e: &E) -> u32 {
     let value = e.to_u32();
-    assert!(value < u32::BITS as u32,
-            "EnumSet only supports up to {} variants.", u32::BITS - 1);
+    assert!(value < 32, "EnumSet only supports up to {} variants.", 31);
     1 << value
 }
 


### PR DESCRIPTION
Since u32:BITS is still in flux, at least as far as where it will end up being stabilized down the road, this patch aims to get enum-set compiling on the beta channel.

I've gated use of the unstable `u32::BITS` behind a feature gate, which you can access on the nightly channel by running cargo with `--features=unstable`. To compile on the stable channel I've just replaced usage of `u32::BITS` with a hard-coded 32. Eventually when some method for getting the number of bits of a type is stabilized we'd definitely want to switch back, however since an unsigned 32-bit integer will definitely be 32 bits (as far as I'm aware) this should be ok until things stabilize.

I also noticed the test crate doesn't seem to be used so I removed it, let me know if this was ok.
