### PR TITLE
Make new_with_bits public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,7 @@ impl<E: CLike> EnumSet<E> {
         Self::new_with_bits(0)
     }
 
-    fn new_with_bits(bits: u32) -> Self {
+    pub fn new_with_bits(bits: u32) -> Self {
         EnumSet { bits: bits, phantom: PhantomData }
     }
 


### PR DESCRIPTION
There is no way to initialize an EnumSet with an existing value. This change makes that possible by switching `new_with_bits` to be public.
